### PR TITLE
Fix visible option in cli to work and fullApi to download initial photos

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -69,6 +69,10 @@ export class Post extends Instagram<TSinglePost> {
   private readonly ids: string[];
 
   constructor(ids: string[], options: IOptions = {}) {
+    // fullAPI option makes no sense for Post class
+    // But usage with fullAPI option brings an extra post, because of scrapeDefaultPosts
+    // So we force it to be disabled
+    options.fullAPI = false;
     super("https://instagram.com/p/", ids[0], "", "", options, SinglePost);
     this.ids = ids;
   }

--- a/src/api/instagram.ts
+++ b/src/api/instagram.ts
@@ -266,6 +266,11 @@ export class Instagram<PostType> {
 
     // Log errors
     this.page.on("error", (error) => this.logger.error(error));
+
+    // Gather initial posts from web page
+    if (this.fullAPI) {
+      await this.scrapeDefaultPosts();
+    }
   }
 
   /**

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -89,6 +89,7 @@ function buildParser(args, callback) {
         describe: "Number of posts to download. 0 to download all",
       },
       visible: {
+        boolean: true,
         default: false,
         describe: "Show browser on the screen",
       },


### PR DESCRIPTION
While heavy testing the library (with search functionality), I have found two issues:

- `--visible` cli parameter is not working wihtout explictly passing true `--visible true`
- With `fullApi` option the first page photos are not downloaded

This PR fixes these problems