### PR TITLE
Instamancer: Electron and Asar Packaging

### DIFF
--- a/src/api/instagram.ts
+++ b/src/api/instagram.ts
@@ -10,6 +10,7 @@ import {
     Browser,
     Headers,
     launch,
+    executablePath,
     LaunchOptions,
     Page,
     Request,

--- a/src/api/instagram.ts
+++ b/src/api/instagram.ts
@@ -681,7 +681,7 @@ export class Instagram<PostType> extends EventEmitter {
             await this.browser.close();
 
             // Retry
-            await this.apuppeteer_1();
+            await this.constructPage();
         }
     }
 

--- a/src/api/instagram.ts
+++ b/src/api/instagram.ts
@@ -636,6 +636,7 @@ export class Instagram<PostType> extends EventEmitter {
         // Browser launch options
         const options: LaunchOptions = {
             args,
+            executablePath: executablePath().replace('app.asar', 'app.asar.unpacked'),
             headless: this.headless,
         };
         if (this.executablePath !== undefined) {
@@ -679,7 +680,7 @@ export class Instagram<PostType> extends EventEmitter {
             await this.browser.close();
 
             // Retry
-            await this.constructPage();
+            await this.apuppeteer_1();
         }
     }
 


### PR DESCRIPTION
I created a modification allowing for Instamancer to be used with Electron and ASAR packaging.
This is with the following options when built with electron-packager:

` --asar.unpack='**/node_modules/puppeteer/.local-chromium/**/*'`

Therefore, Puppeteer can run with electron as a secondary chromium instance, and still perform scraping. Thank you.