### PR TITLE
Fixes getting initial photos of a user, which has less then 10 photos

### DIFF
--- a/src/api/instagram.ts
+++ b/src/api/instagram.ts
@@ -137,6 +137,7 @@ export class Instagram<PostType> {
 
     // Number of jumps before exiting because lack of data
     private failedJumps: number = 20;
+    private responseFromAPI: boolean = false;
 
     // Strings denoting the access methods of API objects
     private readonly pageQuery: string;
@@ -434,6 +435,9 @@ export class Instagram<PostType> {
                 continue;
             }
 
+            // Acknowlege receipt of response
+            this.responseFromAPI = true;
+
             // Get JSON data
             let data: JSON;
             try {
@@ -610,8 +614,13 @@ export class Instagram<PostType> {
 
             // Stop if no data is being gathered
             if (this.jumps === this.failedJumps) {
-                this.finished = true;
-                if (this.index === 0) {
+                if (this.fullAPI) {
+                    if (!this.responseFromAPI) {
+                        this.finished = true;
+                    }
+                } else if (this.index === 0) {
+                    this.finished = true;
+
                     const pageContent = {content: ""};
                     try {
                         pageContent.content = await this.page.content();

--- a/src/api/instagram.ts
+++ b/src/api/instagram.ts
@@ -609,18 +609,22 @@ export class Instagram<PostType> {
             await this.jump();
 
             // Stop if no data is being gathered
-            if (this.jumps === this.failedJumps && this.index === 0) {
+            if (this.jumps === this.failedJumps) {
                 this.finished = true;
+                if (this.index === 0) {
+                    const pageContent = {content: ""};
+                    try {
+                        pageContent.content = await this.page.content();
+                    } catch (e) {
+                        // No content
+                    }
 
-                const pageContent = {content: ""};
-                try {
-                    pageContent.content = await this.page.content();
-                } catch (e) {
-                    // No content
+                    this.logger.error(
+                        "Page failed to make requests",
+                        pageContent,
+                    );
+                    break;
                 }
-
-                this.logger.error("Page failed to make requests", pageContent);
-                break;
             }
 
             // Enable grafting if required
@@ -918,9 +922,6 @@ export class Instagram<PostType> {
                 this.pagePromises.push(
                     this.postPage(shortCode, this.postPageRetries),
                 );
-                if (this.index + 1 === shortCodes.length) {
-                    this.finished = true;
-                }
             } else {
                 this.finished = true;
                 break;

--- a/src/api/instagram.ts
+++ b/src/api/instagram.ts
@@ -918,6 +918,9 @@ export class Instagram<PostType> {
                 this.pagePromises.push(
                     this.postPage(shortCode, this.postPageRetries),
                 );
+                if (this.index + 1 === shortCodes.length) {
+                    this.finished = true;
+                }
             } else {
                 this.finished = true;
                 break;

--- a/tests/test.spec.ts
+++ b/tests/test.spec.ts
@@ -151,7 +151,6 @@ describe("Full API", () => {
 });
 
 testWrapper("Account with < 10 photos", async () => {
-    jest.setTimeout(20 * 1000);
     // This is a not well-known account and it can be deleted at any moment
     // If this test starts to fail, need to find another user
     // which has less then 10 photos

--- a/tests/test.spec.ts
+++ b/tests/test.spec.ts
@@ -150,6 +150,28 @@ describe("Full API", () => {
     }
 });
 
+testWrapper("Account with < 10 photos", async () => {
+    jest.setTimeout(20 * 1000);
+    // This is a not well-known account and it can be deleted at any moment
+    // If this test starts to fail, need to find another user
+    // which has less then 10 photos
+    const id = "zhiznizmelochei";
+    const fullApiOption: IOptionsFullApi = {
+        ...libraryTestOptions,
+        fullAPI: true,
+    };
+    const api = createApi("user", id, fullApiOption);
+    const scraped = [];
+    for await (const post of api.generator()) {
+        expect(post).toBeDefined();
+        scraped.push(post);
+    }
+    expect(scraped.length).toBeGreaterThan(0);
+    // If this user will start to do new posts
+    // Need to find a new one
+    expect(scraped.length).toBeLessThan(10);
+});
+
 describe("API limits", () => {
     class ApiTestConditions {
         public api: "hashtag" | "user";


### PR DESCRIPTION
I've found a bug.

### Steps to reproduce

1. Find an Account in Instagram with less then 10 photos
1. Create a `user` api with this account
1. Start to iterate the generator

### Expected

1. Generator to return all photos and return `{ done: true }` at the last one, so iterator stops.

### Actual

1. Generator does returns `{ done: false }` at the last photo, so iterator is frozen and never stops.

### Solution

I've reproduced the error using tests and fixed it by setting `isFinished` property in Instagram instance, if all photos are already processed.