### PR TITLE
feat(Instagram): adds browserInstance option

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,4 +1,5 @@
 import {Type} from "io-ts";
+import {Browser} from "puppeteer";
 import * as winston from "winston";
 import {DType, IPlugin} from "../../plugins";
 import {Instagram} from "./instagram";
@@ -59,6 +60,10 @@ export interface IOptionsCommon {
 
     // Custom io-ts validator
     validator?: Type<unknown>;
+
+    // Pass puppeter Browser instance from outside.
+    // Be careful to close Browser by yourself, when there is no need in it anymore.
+    browserInstance?: Browser;
 }
 
 export interface IOptionsFullApi extends IOptionsCommon {


### PR DESCRIPTION
This PR adds an option to pass your own puppeteer Browser instance to the class constructor options.

It allows you to reuse one Browser, if you use Instamancer using JS API (not cli). This is a must to save CPU and RAM resources in a server application.

I've looked through plugins API to use it to deliver this functionality. 

But firstly, if I understood correctly, plugins eco-system does not allow me to add this kind of functionality.

Secondly, this is a small change in the source code of the project.

Thirdly, this change implements Inversion of Control design patter in this project, by allowing consumers of the library to construct their own browser instance object with the options they need, instead of adding new options to Instamancer options.

Anyway, I will be happy to reimplement this functionality using plugins, if needed.

Looking forward to a successful code review and wish you great holidays,
Alexander.